### PR TITLE
changed file to python3 and edited function bam_to_wig

### DIFF
--- a/bam_to_bigwig.py
+++ b/bam_to_bigwig.py
@@ -143,7 +143,7 @@ def bam_to_wig(bam_filename, wig_filename):
         log.critical('Write permission denied: %s' % (os.path.dirname(os.path.abspath(wig_filename))))
         return False
     #remove secondary alignments
-    filtered_bam_name = 'filtered_' + file_prefix + '.bam'
+    filtered_bam_name = file_prefix + '-filtered.bam'
     cl = ['samtools', 'view', '-F', '3840', bam_filename, '-o', filtered_bam_name]
     p = Popen(cl)
     p.communicate()
@@ -253,7 +253,6 @@ def main(bam_filename, bigwig_filename=None, use_tempfile=False, keep_tempfile=F
     sys.stdout.write(' Done\n')
     
     # run wigToBigWig
-    filtered_bam_name = 'filtered_' + file_prefix + '.bam'
     sys.stdout.write('Building bigwig file: %s ...' % bigwig_filename)
     if not wig_to_bigwig(wig_filename, bigwig_filename, chr_sizes_filename):
         sys.stdout.write(' Failed\n')
@@ -261,6 +260,7 @@ def main(bam_filename, bigwig_filename=None, use_tempfile=False, keep_tempfile=F
     sys.stdout.write(' Done\n')
     
     # remove temp files
+    filtered_bam_name = file_prefix + '-filtered.bam'
     if not keep_tempfile:
         os.remove(chr_sizes_filename)
         os.remove(wig_filename)

--- a/bam_to_bigwig.py
+++ b/bam_to_bigwig.py
@@ -143,11 +143,12 @@ def bam_to_wig(bam_filename, wig_filename):
         log.critical('Write permission denied: %s' % (os.path.dirname(os.path.abspath(wig_filename))))
         return False
     #remove secondary alignments
-    cl = ['samtools', 'view', '-F', '3840', bam_filename, '-o', 'filtered.bam']
+    filtered_bam_name = 'filtered_' + file_prefix + '.bam'
+    cl = ['samtools', 'view', '-F', '3840', bam_filename, '-o', filtered_bam_name]
     p = Popen(cl)
     p.communicate()
     #run rsem with filtered bam file
-    cl = ['rsem-bam2wig', 'filtered.bam', wig_filename, file_prefix, '--no-fractional-weight']
+    cl = ['rsem-bam2wig', filtered_bam_name, wig_filename, file_prefix, '--no-fractional-weight']
     p = Popen(cl)
     p.communicate()
     rc = p.returncode
@@ -262,7 +263,7 @@ def main(bam_filename, bigwig_filename=None, use_tempfile=False, keep_tempfile=F
     if not keep_tempfile:
         os.remove(chr_sizes_filename)
         os.remove(wig_filename)
-        os.remove('filtered.bam')
+        os.remove(filtered_bam_name)
         
 def dependences_exist():
     """The script requires:

--- a/bam_to_bigwig.py
+++ b/bam_to_bigwig.py
@@ -144,6 +144,7 @@ def bam_to_wig(bam_filename, wig_filename):
         return False
     #remove secondary alignments
     filtered_bam_name = 'filtered_' + file_prefix + '.bam'
+    print(filtered_bam_name)
     cl = ['samtools', 'view', '-F', '3840', bam_filename, '-o', filtered_bam_name]
     p = Popen(cl)
     p.communicate()
@@ -253,6 +254,7 @@ def main(bam_filename, bigwig_filename=None, use_tempfile=False, keep_tempfile=F
     sys.stdout.write(' Done\n')
     
     # run wigToBigWig
+    filtered_bam_name = 'filtered_' + file_prefix + '.bam'
     sys.stdout.write('Building bigwig file: %s ...' % bigwig_filename)
     if not wig_to_bigwig(wig_filename, bigwig_filename, chr_sizes_filename):
         sys.stdout.write(' Failed\n')

--- a/bam_to_bigwig.py
+++ b/bam_to_bigwig.py
@@ -144,7 +144,6 @@ def bam_to_wig(bam_filename, wig_filename):
         return False
     #remove secondary alignments
     filtered_bam_name = 'filtered_' + file_prefix + '.bam'
-    print(filtered_bam_name)
     cl = ['samtools', 'view', '-F', '3840', bam_filename, '-o', filtered_bam_name]
     p = Popen(cl)
     p.communicate()

--- a/bam_to_bigwig.py
+++ b/bam_to_bigwig.py
@@ -14,8 +14,7 @@ Usage:
 '''
 
 Dependencies:
-    
-     (https://github.com/pysam-developers/pysam)
+    pysam (https://github.com/pysam-developers/pysam)
     wigToBigWig from UCSC (http://hgdownload.cse.ucsc.edu/admin/exe/)
     rsem-bam2wig from RSEM (http://deweylab.biostat.wisc.edu/rsem/)
 

--- a/bam_to_bigwig.py
+++ b/bam_to_bigwig.py
@@ -14,7 +14,8 @@ Usage:
 '''
 
 Dependencies:
-    pysam (https://github.com/pysam-developers/pysam)
+    
+     (https://github.com/pysam-developers/pysam)
     wigToBigWig from UCSC (http://hgdownload.cse.ucsc.edu/admin/exe/)
     rsem-bam2wig from RSEM (http://deweylab.biostat.wisc.edu/rsem/)
 
@@ -165,8 +166,9 @@ def bam_to_wig(bam_filename, wig_filename):
 @contextmanager
 def indexed_bam(bam_filename):
     import pysam
-    if not os.path.exists(bam_filename + ".bai"):
-        pysam.index(bam_filename)
+    if not os.path.exists(bam_filename + ".csi"): #changed to .csi index instead of .bai
+        #pysam.index(bam_filename) 
+        print("CSI INDEX MISSING") #.csi index should have been created in RNAseq_annotate.py, if you reach this statement something went wrong.
     sam_reader = pysam.Samfile(bam_filename, "rb")
     yield sam_reader
     sam_reader.close()

--- a/bam_to_bigwig.py
+++ b/bam_to_bigwig.py
@@ -144,7 +144,7 @@ def bam_to_wig(bam_filename, wig_filename):
         return False
     #remove secondary alignments
     filtered_bam_name = file_prefix + '-filtered.bam'
-    cl = ['samtools', 'view', '-F', '3840', bam_filename, '-o', filtered_bam_name]
+    cl = ['samtools', 'view', '-F', '3840', '-@', '12', bam_filename, '-o', filtered_bam_name]
     p = Popen(cl)
     p.communicate()
     #run rsem with filtered bam file


### PR DESCRIPTION
1. Change file to python3.
2. Since the latest rsem don't have the option for ignoring secondary alignments,  we use command "samtools view -F 3840" to remove secondary alignment.

The command for using bam_to_bigwig is "bam_to_bigwig.py [name of bam file] -o [name of output bigwig file]" e.g(bam_to_bigwig.py output.bam -o output.bigwig)